### PR TITLE
Example implementation of a custom LeakCanary ObjectInspector for RIBs routers

### DIFF
--- a/android/demos/memory-leaks/src/main/java/com/uber/rib/SampleApplication.java
+++ b/android/demos/memory-leaks/src/main/java/com/uber/rib/SampleApplication.java
@@ -19,7 +19,12 @@ import android.app.Application;
 import com.uber.rib.core.ActivityDelegate;
 import com.uber.rib.core.HasActivityDelegate;
 import com.uber.rib.core.RibRefWatcher;
+import com.uber.rib.core.RouterInspector;
+import java.util.ArrayList;
+import java.util.List;
 import leakcanary.AppWatcher;
+import leakcanary.LeakCanary;
+import shark.ObjectInspector;
 
 public class SampleApplication extends Application implements HasActivityDelegate {
 
@@ -34,6 +39,14 @@ public class SampleApplication extends Application implements HasActivityDelegat
 
   /** Install leak canary for both activities and RIBs. */
   private void installLeakCanary() {
+    LeakCanary.Config config = LeakCanary.getConfig();
+    List<ObjectInspector> objectInspectors = new ArrayList<>(config.getObjectInspectors());
+    objectInspectors.add(new RouterInspector());
+    LeakCanary.setConfig(
+        config.newBuilder()
+            .objectInspectors(objectInspectors)
+            .build()
+    );
     RibRefWatcher.getInstance()
         .setReferenceWatcher(
             new RibRefWatcher.ReferenceWatcher() {

--- a/android/libraries/rib-base/build.gradle
+++ b/android/libraries/rib-base/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     implementation deps.apt.javaxInject
 
     implementation deps.uber.autodisposeCoroutines
+    implementation "com.squareup.leakcanary:shark:2.10"
+    implementation "com.squareup.leakcanary:shark-graph:2.10"
     implementation deps.kotlin.coroutinesRx2
     api deps.kotlin.stdlib
     api deps.kotlin.coroutines

--- a/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/RouterInspector.kt
+++ b/android/libraries/rib-base/src/main/kotlin/com/uber/rib/core/RouterInspector.kt
@@ -1,0 +1,30 @@
+package com.uber.rib.core
+
+import shark.ObjectInspector
+import shark.ObjectReporter
+import shark.HeapObject.HeapInstance
+
+public class RouterInspector : ObjectInspector {
+  override fun inspect(reporter: ObjectReporter) {
+    val heapObject = reporter.heapObject
+    if (heapObject is HeapInstance && heapObject instanceOf "com.uber.rib.core.Router") {
+      val interactor = heapObject["com.uber.rib.core.Router", "interactor"]!!.valueAsInstance!!
+      if (interactor instanceOf "com.uber.rib.core.Interactor") {
+        val lifecycleFlow =
+          interactor["com.uber.rib.core.Interactor", "_lifecycleFlow"]!!.valueAsInstance!!
+        // lifecycleFlow is always a MutableSharedFlow
+        val buffer =
+          lifecycleFlow["kotlinx.coroutines.flow.SharedFlowImpl", "buffer"]!!.valueAsObjectArray!!.readElements().toList()
+        val replayIndex = lifecycleFlow["kotlinx.coroutines.flow.SharedFlowImpl", "replayIndex"]!!.value.asLong!!.toInt()
+        val interactorEvent = buffer[replayIndex].asObject?.asInstance!!
+        val enumName =
+          interactorEvent["java.lang.Enum", "name"]!!.valueAsInstance!!.readAsJavaString()
+        if (enumName == "INACTIVE") {
+          reporter.leakingReasons += "interactor._lifecycleFlow is INACTIVE"
+        } else {
+          reporter.notLeakingReasons += "interactor._lifecycleFlow is ACTIVE"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I'm opening a draft PR and closing it immediately as I have no intention to merge this anywhere, just showing the realm of what's possible with LeakCanary custom ObjectInspectors.

Before vs After. Notice how the number of suspected references goes from 3 down to 1.

<img width="645" alt="image" src="https://github.com/pyricau/RIBs/assets/557033/7a55f10b-dbbf-4277-bff5-64cecbb4e365">

cc @tyvsmith

